### PR TITLE
Corrected install instructions. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ In order to install Tarpon, execute the following autotools commands:
     $ make install
     $ pip install -r requirements.txt
 
-Uninstall Tarpon using ``make uninstall`` or install Tarpon locally (rather than system-wide) by executing ``./configure --prefix=/home/$USER/.local`` before executing ``make``. A distributable package can be built using ``make dist``.
+Uninstall Tarpon using ``make uninstall`` or install Tarpon locally
+(rather than system-wide) by executing ``./configure --prefix=$HOME/.local``
+before executing ``make``. A distributable package can be built using ``make dist``.
 
 FAQ
 ---

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ In order to install Tarpon, execute the following autotools commands:
     $ ./autogen.sh
     $ make
     $ make install
+    $ pip install -r requirements.txt
 
-Uninstall Tarpon using ``make uninstall`` or install Tarpon locally (rather than system-wide) by executing ``./configure --prefix=~/.local`` before executing ``make``. A distributable package can be built using ``make dist``.
+Uninstall Tarpon using ``make uninstall`` or install Tarpon locally (rather than system-wide) by executing ``./configure --prefix=/home/$USER/.local`` before executing ``make``. A distributable package can be built using ``make dist``.
 
 FAQ
 ---


### PR DESCRIPTION
The python requirements need to be installed and ./configure --prefix=~/.local needs an absolute path.
